### PR TITLE
Replace date with local date

### DIFF
--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -25,7 +25,16 @@
             <artifactId>groovy-all</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.9.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.6</version>
+        </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>

--- a/groovy/src/test/groovy/cucumber/runtime/groovy/date_stepdefs.groovy
+++ b/groovy/src/test/groovy/cucumber/runtime/groovy/date_stepdefs.groovy
@@ -1,10 +1,8 @@
 package cucumber.runtime.groovy
 
-import java.text.DateFormat
+import java.time.LocalDate
 
 import static groovy.util.GroovyTestCase.assertEquals
-import static java.text.DateFormat.MEDIUM
-import static java.util.Locale.ENGLISH
 
 this.metaClass.mixin(cucumber.api.groovy.Hooks)
 this.metaClass.mixin(cucumber.api.groovy.EN)
@@ -14,10 +12,10 @@ class DateWrapper {
 }
 
 Given('today\'s date is "{date}" and tomorrow is:') { DateWrapper today, String tomorrow ->
-    assertEquals(3, today.date.date)
+    assertEquals(3, today.date.getDayOfMonth())
     assertEquals('1971-10-04',tomorrow)
 }
 
-And('anonymous date is {}') { Date parsedDate ->
-    assertEquals(DateFormat.getDateInstance(MEDIUM, ENGLISH).parse("Jan 19, 2011"), parsedDate)
+And('anonymous date is {}') { LocalDate parsedDate ->
+    assertEquals(LocalDate.of(2011, 1, 19), parsedDate)
 }


### PR DESCRIPTION
I had some problems running tests locally. The `And anonymous date is 2011-01-19` step failed because `(DateFormat.getDateInstance(MEDIUM, ENGLISH).parse("Jan 19, 2011")` will parse dates to the local timezone while Jackson internally parses dates to UTC which are then converted to the local timezone. Rather then trying to work out why this failed, I've upgraded all date stuff to use `LocalDate` instead -- this avoids all problems with date in the first place.